### PR TITLE
More complete NYC Taxi data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -446,6 +446,7 @@ Transportation
 * `Hubway Million Rides in MA <http://hubwaydatachallenge.org/trip-history-data/>`_
 * `Marine Traffic - ship tracks, port calls and more <https://www.marinetraffic.com/de/p/api-services>`_
 * `NYC Taxi Trip Data 2013 (FOIA/FOILed) <https://archive.org/details/nycTaxiTripData2013>`_
+* `NYC Taxi Trip Data 2009- <http://www.nyc.gov/html/tlc/html/about/trip_record_data.shtml>`_
 * `OpenFlights - airport, airline and route data <http://openflights.org/data.html>`_
 * `RITA Airline On-Time Performance data <http://www.transtats.bts.gov/Tables.asp?DB_ID=120>`_
 * `RITA/BTS transport data collection (TranStat) <http://www.transtats.bts.gov/DataIndex.asp>`_


### PR DESCRIPTION
This is a more complete NYC Taxi dataset hosted directly on the NYC TLC website. It goes all the way back to 2009 and up to 2015! It includes data on both yellow and green cars, and has all the same fields as the FOILed data. 

I wasn't sure if I should replace the old link, so I just added a new entry below the previous one. :)