### PR TITLE
Add Zenodo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -467,3 +467,4 @@ Complementary Collections
 * StaTrek: `Leveraging open data to understand urban lives <http://xiaming.me/posts/2014/10/23/leveraging-open-data-to-understand-urban-lives/>`_
 * OpenDataMonitor: `An overview of available open data resources in Europe <http://opendatamonitor.eu>`_
 * OpenDataNetwork: `A search engine of all Socrata powered data portals ranging from small cities to federal agencies and non-profits <http://opendatanetwork.com>`_
+* Zenodo: `An open dependable home for the long-tail of science, enabling researchers to share and preserve any research outputs in any size, any format and from any science. <https://zenodo.org/collection/datasets>`_


### PR DESCRIPTION
Zenodo is an open dependable home for the long-tail of science, enabling researchers to share and preserve any research outputs in any size, any format and from any science. Powered by CERN and INVENIO. See https://zenodo.org/features.

Direct link to the data sets: https://zenodo.org/collection/datasets