### PR TITLE
New museums entry and reordering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -299,9 +299,10 @@ Museums
 
 * `Cooper-Hewitt's Collection Database <https://github.com/cooperhewitt/collection>`_
 * `Minneapolis Institute of Arts metadata <https://github.com/artsmia/collection>`_
+* `Natural History Museum (London) Data Portal <http://data.nhm.ac.uk/>`_
+* `Rijksmuseum Historical Art Collection <https://www.rijksmuseum.nl/en/api>`_
 * `Tate Collection metadata <https://github.com/tategallery/collection>`_
 * `The Getty vocabularies <http://vocab.getty.edu>`_
-* `Rijksmuseum Historical Art Collection <https://www.rijksmuseum.nl/en/api>`_
 
 
 Natural Language


### PR DESCRIPTION
Added a new record for the British Natural History Museum Data Portal (http://data.nhm.ac.uk/) which has just launched in Beta. Also re-ordered the Museum entries to be alphabetical.