### PR TITLE
Add Rapid7 Sonar internet scans

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,7 @@ Computer Networks
 * `CRAWDAD Wireless datasets from Dartmouth Univ. <https://crawdad.cs.dartmouth.edu/>`_
 * `Criteo click-through data <http://labs.criteo.com/2015/03/criteo-releases-its-new-dataset/>`_
 * `Open Mobile Data by MobiPerf <https://console.developers.google.com/storage/openmobiledata_public/>`_
+* `Rapid7 Sonar Internet Scans <https://sonar.labs.rapid7.com/>`_ 
 * `UCSD Network Telescope, IPv4 /8 net <http://www.caida.org/projects/network_telescope/>`_
 
 


### PR DESCRIPTION
These scans are part of a research project run by Rapid7 Labs called "Sonar" (http://sonar.labs.rapid7.com/). Essentially we're trying to raise awareness about misconfigurations and potential security threats by looking at internet-wide service deployments.  We're collecting the data and sharing it publicly so security professionals can apply the findings to their organization’s environment and mitigate the related risks.

Thanks for adding! 