### PR TITLE
Add Numerai to Data Challenges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,7 @@ Contextual Data
 Data Challenges
 ---------------
 
+* `Numerai: a global AI tournament to predict the stock market <https://numer.ai/>`_
 * `Challenges in Machine Learning <http://www.chalearn.org/>`_
 * `CrowdANALYTIX dataX <http://data.crowdanalytix.com>`_
 * `D4D Challenge of Orange <http://www.d4d.orange.com/en/home>`_


### PR DESCRIPTION
Adds a link to [Numerai](https://numer.ai):

> The Numerai Tournament provides financial data on which anyone can build a machine learning model. Participants download the data, build a model, and upload their predictions. These predictions then manage a global equities hedge fund. Numerai scores submittals for predictive power, and awards cash prizes for the top submissions. Hundreds of top data scientists around the world have participated in the Numerai Tournament since it began last December.
