### PR TITLE
Adding Broad Bioimage Benchmark Collection (BBBC)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Biology
 * `1000 Genomes <http://www.1000genomes.org/data>`_
 * `American Gut (Microbiome Project) <https://github.com/biocore/American-Gut>`_
 * `Broad Cancer Cell Line Encyclopedia (CCLE) <http://www.broadinstitute.org/ccle/home>`_
+* `Broad Bioimage Benchmark Collection (BBBC) <https://www.broadinstitute.org/bbbc>`_
 * `Cell Image Library <http://www.cellimagelibrary.org>`_
 * `Collaborative Research in Computational Neuroscience (CRCNS) <http://crcns.org/data-sets>`_
 * `Complete Genomics Public Data <http://www.completegenomics.com/public-data/69-genomes/>`_


### PR DESCRIPTION
The Broad Bioimage Benchmark Collection ([BBBC](https://www.broadinstitute.org/bbbc/)) is a large curated collection of published data sets in bio imaging. It includes images, metadata and ground truths. The BBBC resource is described in the following publication: 

Ljosa V, Sokolnicki KL, Carpenter AE (2012). **Annotated high-throughput microscopy image sets for validation**. Nature Methods 9(7):637 / doi. PMID: 22743765 PMCID: PMC3627348. Available at http://dx.doi.org/10.1038/nmeth.2083