### PR TITLE
New Yorker caption contest ratings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -307,6 +307,7 @@ Machine Learning
 * `Machine Learning Data Set Repository <http://mldata.org/>`_
 * `Million Song Dataset <http://labrosa.ee.columbia.edu/millionsong/>`_
 * `More Song Datasets <http://labrosa.ee.columbia.edu/millionsong/pages/additional-datasets>`_
+* `New Yorker caption contest ratings <https://github.com/nextml/caption-contest-data>`_
 * `MovieLens Data Sets <http://grouplens.org/datasets/movielens/>`_
 * `RDataMining - "R and Data Mining" ebook data <http://www.rdatamining.com/data>`_
 * `Registered Meteorites on Earth <http://healthintelligence.drupalgardens.com/content/registered-meteorites-has-impacted-earth-visualized>`_


### PR DESCRIPTION
Publishes link to the New Yorker caption contest ratings.

An entry in this dataset is of the form "caption 'funny caption text' was rated 2 by user i". To date, we have collected roughly 3.3 million responses of this form.

I am a little uncertain about what section is most appropriate. I put it in "Machine learning" because we provide both the captions and the rating for the caption, and this is at it's core a machine learning project.