### PR TITLE
Exchange rates from Ukraine and Russia

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,7 @@ Finance
 * `St Louis Federal <https://research.stlouisfed.org/fred2/>`_
 * `Yahoo Finance <http://finance.yahoo.com/>`_
 * `NYSE Market Data <ftp://ftp.nyxdata.com>`_ (see FTP link on `RAW <https://raw.githubusercontent.com/caesar0301/awesome-public-datasets/master/README.rst>`_)
+* `Exchange rates in Ukraine and Russia (Cash, Visa, Mastercard, Interbank, Webmoney) <https://www.datacrucis.com/datasets.html>`_
 
 
 GIS


### PR DESCRIPTION
Add link to the archive of various exchange rates between main currencies in Ukraine and Russia. Available in JSON and CSV under Creative Commons Attribution 4.0 International License