### PR TITLE
Fix broken link to Transport for London open datasets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -579,7 +579,7 @@ Transportation
 * `RITA Airline On-Time Performance data <http://www.transtats.bts.gov/Tables.asp?DB_ID=120>`_
 * `RITA/BTS transport data collection (TranStat) <http://www.transtats.bts.gov/DataIndex.asp>`_
 * `Toronto Bike Share Stations (XML file) <http://www.bikesharetoronto.com/data/stations/bikeStations.xml>`_
-* `Transport for London (TFL) <https://tfl.gov.uk/info-for/open-data-users/data-feeds>`_
+* `Transport for London (TFL) <https://tfl.gov.uk/info-for/open-data-users/our-open-data>`_
 * `Travel Tracker Survey (TTS) for Chicago <http://www.cmap.illinois.gov/data/transportation/travel-tracker-survey>`_
 * `U.S. Bureau of Transportation Statistics (BTS) <http://www.rita.dot.gov/bts/>`_
 * `U.S. Domestic Flights 1990 to 2009 <http://academictorrents.com/details/a2ccf94bbb4af222bf8e69dad60a68a29f310d9a>`_


### PR DESCRIPTION
The link to Transport for London datasets was broken. This PR fixes it.