### PR TITLE
Add Free Music Archive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -319,6 +319,7 @@ Machine Learning
 * `Labeled Faces in the Wild (LFW) <http://vis-www.cs.umass.edu/lfw/>`_
 * `Lending Club Loan Data <https://www.lendingclub.com/info/download-data.action>`_
 * `Machine Learning Data Set Repository <http://mldata.org/>`_
+* `Free Music Archive <https://github.com/mdeff/fma>`_
 * `Million Song Dataset <http://labrosa.ee.columbia.edu/millionsong/>`_
 * `More Song Datasets <http://labrosa.ee.columbia.edu/millionsong/pages/additional-datasets>`_
 * `MovieLens Data Sets <http://grouplens.org/datasets/movielens/>`_


### PR DESCRIPTION
# Overview

* `Free Music Archive <https://github.com/mdeff/fma>`_

A dataset made of 106,574 tracks, 16,341 artists, 14,854 albums, arranged in a hierarchical taxonomy of 161 genres, for a total of 343 days of audio and 917 GiB, all under permissive Creative Commons licenses. It features metadata like song title, album, artist and genres; user data like play counts, favorites, and comments; free-form text like description, biography, and tags; together with full-length, high-quality audio, and some pre-computed features.

Code & data: <https://github.com/mdeff/fma>
Paper: <https://arxiv.org/abs/1612.01840>