### PR TITLE
Add Indie Map

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -472,6 +472,7 @@ Social Networks
 * `GitHub Collaboration Archive <https://www.githubarchive.org/>`_
 * `Google Scholar citation relations <http://www3.cs.stonybrook.edu/~leman/data/gscholar.db>`_
 * `High-Resolution Contact Networks from Wearable Sensors <http://www.sociopatterns.org/datasets/>`_
+* `Indie Map: social graph and crawl of top IndieWeb sites <http://www.indiemap.org/>`_
 * `Mobile Social Networks from UMASS <https://kdl.cs.umass.edu/display/public/Mobile+Social+Networks>`_
 * `Network Twitter Data <http://snap.stanford.edu/data/higgs-twitter.html>`_
 * `Reddit Comments <https://www.reddit.com/r/datasets/comments/3bxlg7/i_have_every_publicly_available_reddit_comment/>`_


### PR DESCRIPTION
# Indie Map

The [IndieWeb](https://indieweb.org/) is a people-focused alternative to the "corporate" web. Participants use their own personal web sites to post, reply, share, organize events and RSVP, and interact in online social networking in ways that have otherwise been limited to centralized silos like Facebook and Twitter.

[Indie Map](http://www.indiemap.org/) is a complete crawl of 2300 of the most active IndieWeb sites, sliced and diced and rolled up in a few useful ways:

* Full social graph dataset, API, and interactive map.
* SQL queryable dataset and GUI analytics, per page and per site.
* Raw crawl data in WARC format: 2300 sites, 5.7M pages, 706k relationships, 380GB HTML + mf2.

More details in the [web site](http://www.indiemap.org/) and [docs](http://www.indiemap.org/docs.html)!