### PR TITLE
Add Enigma Public & archive.org's data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -416,15 +416,17 @@ Public Domains
 --------------
 
 * `Amazon <http://aws.amazon.com/datasets/>`_
-* `Archive-it from Internet Archive <https://www.archive-it.org/explore?show=Collections>`_
 * `Archive.org Datasets <https://archive.org/details/datasets>`_
 * `CMU JASA data archive <http://lib.stat.cmu.edu/jasadata/>`_
 * `CMU StatLab collections <http://lib.stat.cmu.edu/datasets/>`_
 * `Data.World <https://data.world>`_
 * `Data360 <http://www.data360.org/index.aspx>`_
 * `Datamob.org <http://datamob.org/datasets>`_
+* `Enigma Public <https://public.enigma.com/>`_
 * `Google <http://www.google.com/publicdata/directory>`_
 * `Infochimps <http://www.infochimps.com/>`_
+* `Internet Archive: Archive-It <https://www.archive-it.org/explore?show=Collections>`_
+* `Internet Archive: The Data Collection <https://archive.org/details/datasets>`_
 * `KDNuggets Data Collections <http://www.kdnuggets.com/datasets/index.html>`_
 * `Microsoft Azure Data Market Free DataSets <http://datamarket.azure.com/browse/data?price=free>`_
 * `Microsoft Data Science for Research <http://aka.ms/Data-Science>`_


### PR DESCRIPTION
# Overview

* Adding [Enigma Public](https://public.enigma.com/) to the public domain sources and adding the Internet Archive's data-specific sources.
* Enigma's not a primary source of data, but it is a source of a lot of (more easily usable) data in the public domain, like Amazon, data.world, etc. listed in the section.
