### PR TITLE
Remove broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -543,7 +543,6 @@ Software
 Sports
 ------
 
-* `Basketball (NBA/NCAA/Euro) Player Database and Statistics <http://www.draftexpress.com/stats.php>`_
 * `Betfair Historical Exchange Data <http://data.betfair.com/>`_
 * `Cricsheet Matches (cricket) <http://cricsheet.org/>`_
 * `Ergast Formula 1, from 1950 up to date (API) <http://ergast.com/mrd/db>`_


### PR DESCRIPTION
The link to the DraftExpress basketball datasets is broken.
The pages http://www.draftexpress.com/stats/nba, http://www.draftexpress.com/stats/ncaa, http://www.draftexpress.com/stats/euroleague do exist, but it looks like there's no downloadable dataset there at the moment.